### PR TITLE
MINOR: don't try and create default records if no ShopConfig

### DIFF
--- a/code/Country.php
+++ b/code/Country.php
@@ -391,14 +391,20 @@ class Country_Billing extends Country {
 
 			$shopConfig = ShopConfig::current_shop_config();
 
-			foreach (self::$iso_3166_countryCodes as $code => $title) {
-				$country = new Country_Billing();
-				$country->Code = $code;
-				$country->Title = $title;
-				$country->ShopConfigID = $shopConfig->ID;
-				$country->write();
+			if (isset($shopConfig->ID)) {
+				foreach (self::$iso_3166_countryCodes as $code => $title) {
+					$country = new Country_Billing();
+					$country->Code = $code;
+					$country->Title = $title;
+					$country->ShopConfigID = $shopConfig->ID;
+					$country->write();
+				}
+				DB::alteration_message('Billing countries created', 'created');
+			} else {
+				DB::alteration_message('Billing countries not created, please re-run /dev/build', 'error');
 			}
-			DB::alteration_message('Billing countries created', 'created');
+			
+			
 		}
 	}
 


### PR DESCRIPTION
Fixes a bug on installing both swipestripe and swipestripe-addresses at the same time.
