### PR TITLE
API: Removing Customer class references.

### DIFF
--- a/_config/addresses.yml
+++ b/_config/addresses.yml
@@ -5,7 +5,7 @@ name: SwipeStripe Addresses
 Order:
   extensions: 
     - 'Addresses_Order'
-Customer:
+Member:
   extensions: 
     - 'Addresses_Customer'
 OrderForm:

--- a/code/Address.php
+++ b/code/Address.php
@@ -38,7 +38,7 @@ class Address extends DataObject {
 	 * @var Array
 	 */
 	private static $has_one = array(
-		'Member' => 'Customer',  
+		'Member' => 'Member',  
 		'Country' => 'Country',
 		'Region' => 'Region'
 	);

--- a/code/Addresses.php
+++ b/code/Addresses.php
@@ -181,6 +181,11 @@ class Addresses_Customer extends DataExtension {
 		}
 		return null;
 	}
+
+	public function updateCMSFields(FieldList $fields) {
+		$fields->removeByName('ShippingAddresses');
+		$fields->removeByName('BillingAddresses');
+	}
 }
 
 class Addresses_OrderForm extends Extension {
@@ -263,7 +268,7 @@ class Addresses_OrderForm extends Extension {
 
 	public function updatePopulateFields(&$data) {
 
-		$member = Customer::currentUser() ? Customer::currentUser() : singleton('Customer');
+		$member = Member::currentUser() ? Member::currentUser() : singleton('Member');
 
 		$shippingAddress = $member->ShippingAddress();
 		$shippingAddressData = ($shippingAddress && $shippingAddress->exists()) 


### PR DESCRIPTION
Removing references to Customer class, relies on new major version of SwipeStripe. References swipestripe/silverstripe-swipestripe#42.
