### PR TITLE
Use proper naming convention for config blocks

### DIFF
--- a/_config/addresses.yml
+++ b/_config/addresses.yml
@@ -1,5 +1,5 @@
 ---
-name: SwipeStripe Addresses
+name: swipestripeaddresses
 ---
 
 Order:


### PR DESCRIPTION
This allows address config to be overridden with before / after priority arguments. The config parser does not accept spaces.
